### PR TITLE
Slush fund? No, SLASH fun

### DIFF
--- a/R/simpleCache.R
+++ b/R/simpleCache.R
@@ -108,7 +108,7 @@ simpleCache = function(cacheName, instruction=NULL, buildEnvir=NULL,
 			parse = FALSE
 		}
 	}
-	if(!is.null(cacheSubDir)) {
+	if (!is.null(cacheSubDir)) {
 		cacheDir = file.path(cacheDir, cacheSubDir)
 	}
 	if (is.null(cacheDir)) {
@@ -116,12 +116,11 @@ simpleCache = function(cacheName, instruction=NULL, buildEnvir=NULL,
 		or specify a cacheDir parameter directly to simpleCache()."))
 		return(NA)
 	}
-	if(!"character" %in% class(cacheName)) {
+	if (!"character" %in% class(cacheName)) {
 		stop("simpleCache expects the cacheName variable to be a character
 		vector.")
 	}
 	
-	cacheDir = enforceTrailingSlash(cacheDir)
 	if (!file.exists(cacheDir)) {
 		dir.create(cacheDir, recursive=TRUE)
 	}
@@ -325,8 +324,6 @@ downloadCache = function(object, url, env=NULL, reload=FALSE, recreate=FALSE,
 		local cacheDir parameter."))
 		return(NA)
 	}
-
-	cacheDir = enforceTrailingSlash(cacheDir)
 
 	if (!file.exists(cacheDir)) {
 		dir.create(cacheDir)

--- a/R/storeCache.R
+++ b/R/storeCache.R
@@ -38,11 +38,10 @@ storeCache = function(cacheName, cacheDir = getOption("RCACHE.DIR"),
 		character vector."))
 	}
 
-	cacheDir = enforceTrailingSlash(cacheDir)
 	if (!file.exists(cacheDir)) {
 		dir.create(cacheDir, recursive=TRUE)
 	}
-	cacheFile = paste0(cacheDir, cacheName, ".RData")
+	cacheFile = file.path(cacheDir, paste0(cacheName, ".RData"))
 	if(file.exists(cacheFile) & !recreate) {
 		message("::Cache already exists (use recreate to overwrite)::\t",
 		cacheFile)

--- a/R/utility.R
+++ b/R/utility.R
@@ -10,11 +10,6 @@
 # These functions should probably remain interior to the package (not exported)
 #
 
-# check for, and fix, trailing slash. if necessary
-enforceTrailingSlash = function(folder) {
-	enforceEdgeCharacter(folder, appendChar="/")
-}
-
 enforceEdgeCharacter = function(string, prependChar="", appendChar="") {
 	if (string=="" | is.null(string)) {
 		return(string)


### PR DESCRIPTION
As discussed in https://github.com/databio/simpleCache/pull/8, `file.path` alleviates the need to have logic in place for explicitly handling and enforcing slashes in/on filepaths.

This also catches one more `paste0` --> `file.path` conversion spot.