### PR TITLE
minimal examples for `simpleCache()` doc

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,4 +24,4 @@ VignetteBuilder: knitr
 License: GPL-3
 URL: http://www.github.com/databio/simpleCache
 BugReports: http://www.github.com/databio/simpleCache
-RoxygenNote: 6.0.1
+RoxygenNote: 6.0.1.9000

--- a/R/simpleCache.R
+++ b/R/simpleCache.R
@@ -80,8 +80,21 @@ NULL
 #'     cluster resource managers. Used as the `res` argument to
 #'     batchtools::batchMap()
 #' @param pepSettings Experimental untested feature.
-#' @param  ignoreLock   internal parameter used for batch job submission; don't
+#' @param ignoreLock   internal parameter used for batch job submission; don't
 #'     touch.
+#'     
+#' @examples 
+#' # speciy directory for cache
+#' setCacheDir("~")
+#' 
+#'# create cache and object
+#' simpleCache("normSample", { rnorm(1e7, 0,1) })
+#' 
+#' # remove object
+#' rm(normSample)
+#' 
+#' # reload object from cache
+#' simpleCache("normSample")
 #' @export
 
 simpleCache = function(cacheName, instruction=NULL, buildEnvir=NULL,

--- a/man/simpleCache.Rd
+++ b/man/simpleCache.Rd
@@ -106,6 +106,19 @@ Because R uses lexical scope and not dynamic scope, you may need to pass some
 environment variables you use in your instruction code. You can use this
 using the parameter buildEnvir (just provide a list of named variables).
 }
+\examples{
+# speciy directory for cache
+setCacheDir("~")
+
+# create cache and object
+simpleCache("normSample", { rnorm(1e7, 0,1) })
+
+# remove object
+rm(normSample)
+
+# reload object from cache
+simpleCache("normSample")
+}
 \references{
 \url{https://github.com/nsheff/}
 }


### PR DESCRIPTION
added a single example to `simpleCache()` per CRAN note ... examples could certainly be fleshed out further ... but devtools::check() now reports `* checking examples ... OK`